### PR TITLE
Enable binding to multiple object paths and support structure bindings

### DIFF
--- a/dbus-client/src/main/java/at/yawk/dbus/client/CallSiteBuilder.java
+++ b/dbus-client/src/main/java/at/yawk/dbus/client/CallSiteBuilder.java
@@ -26,6 +26,7 @@ import at.yawk.dbus.client.request.Request;
 import at.yawk.dbus.client.request.RequestExecutor;
 import at.yawk.dbus.client.request.Response;
 import at.yawk.dbus.databind.DataBinder;
+import at.yawk.dbus.databind.annotation.Struct;
 import at.yawk.dbus.databind.binder.Binder;
 import at.yawk.dbus.databind.binder.PrimitiveAnnotationBinderTransformer;
 import at.yawk.dbus.databind.binder.TypeUtil;
@@ -35,7 +36,9 @@ import at.yawk.dbus.protocol.object.BasicObject;
 import at.yawk.dbus.protocol.object.DbusObject;
 import at.yawk.dbus.protocol.object.ObjectPathObject;
 import at.yawk.dbus.protocol.object.StringObject;
+import at.yawk.dbus.protocol.object.StructObject;
 import at.yawk.dbus.protocol.type.BasicType;
+import at.yawk.dbus.protocol.type.StructTypeDefinition;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.AnnotatedType;
@@ -49,6 +52,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -98,6 +102,8 @@ class CallSiteBuilder implements Request {
     int timeout = -1;
     TimeUnit timeoutUnit;
 
+    private Class returnClass;
+    
     /**
      * @param childTransient If set to {@code true}, the returned call site will not be decorated from anything but
      *                       {@link #decorateFromCall(Object[])}.
@@ -129,6 +135,7 @@ class CallSiteBuilder implements Request {
 
         child.timeout = timeout;
         child.timeoutUnit = timeoutUnit;
+        child.returnClass = returnClass;
         return child;
     }
 
@@ -173,6 +180,8 @@ class CallSiteBuilder implements Request {
     void decorateFromMethod(DataBinder dataBinder, Method method) {
         decorateFromAnnotations(method);
 
+        returnClass = method.getReturnType();
+        
         Type[] genericParameterTypes = method.getGenericParameterTypes();
 
         if (markedWithListener) {
@@ -356,7 +365,12 @@ class CallSiteBuilder implements Request {
     }
 
     private Object decodeReply(List<DbusObject> reply) {
-        return returnBinder.decode(reply.get(0));
+        if(reply.size() > 1 && returnClass.getAnnotation(Struct.class) != null) {
+            StructObject so = StructObject.create(new StructTypeDefinition(reply.stream().map(d -> d.getType()).collect(Collectors.toList())), reply);
+            return returnBinder.decode(so);
+        } else {
+            return returnBinder.decode(reply.get(0));
+        }
     }
 
     private static <A extends Annotation> void ifPresent(AnnotatedElement element, Class<A> annotationClass,

--- a/dbus-client/src/main/java/at/yawk/dbus/client/DBUSDestination.java
+++ b/dbus-client/src/main/java/at/yawk/dbus/client/DBUSDestination.java
@@ -1,0 +1,8 @@
+
+package at.yawk.dbus.client;
+
+public interface DBUSDestination {
+    public String getBus();
+    public String getDestination();
+    public String getObjectPath();
+}

--- a/dbus-client/src/main/java/at/yawk/dbus/client/DBUSDestinationImpl.java
+++ b/dbus-client/src/main/java/at/yawk/dbus/client/DBUSDestinationImpl.java
@@ -1,0 +1,79 @@
+
+package at.yawk.dbus.client;
+
+import java.util.Objects;
+
+public class DBUSDestinationImpl implements DBUSDestination {
+    private final String bus;
+    private final String destination;
+    private final String objectPath;
+
+    public DBUSDestinationImpl() {
+        this.bus = null;
+        this.destination = null;
+        this.objectPath = null;
+    }
+
+    public DBUSDestinationImpl(String bus, String destination, String objectPath) {
+        this.bus = bus;
+        this.destination = destination;
+        this.objectPath = objectPath;
+    }
+
+    public String getBus() {
+        return bus;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+
+    public String getObjectPath() {
+        return objectPath;
+    }
+    
+    public DBUSDestinationImpl withBus(String bus) {
+        return new DBUSDestinationImpl(bus, this.getDestination(), this.getObjectPath());
+    }
+    
+     public DBUSDestinationImpl withDestination(String destination) {
+        return new DBUSDestinationImpl(this.getBus(), destination, this.getObjectPath());
+    }
+
+    public DBUSDestinationImpl withObjectPath(String objectPath) {
+        return new DBUSDestinationImpl(this.getBus(), this.getDestination(), objectPath);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 47 * hash + Objects.hashCode(this.bus);
+        hash = 47 * hash + Objects.hashCode(this.destination);
+        hash = 47 * hash + Objects.hashCode(this.objectPath);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final DBUSDestinationImpl other = (DBUSDestinationImpl) obj;
+        if (!Objects.equals(this.bus, other.bus)) {
+            return false;
+        }
+        if (!Objects.equals(this.destination, other.destination)) {
+            return false;
+        }
+        if (!Objects.equals(this.objectPath, other.objectPath)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/dbus-client/src/main/java/at/yawk/dbus/client/DbusClient.java
+++ b/dbus-client/src/main/java/at/yawk/dbus/client/DbusClient.java
@@ -95,6 +95,7 @@ public class DbusClient implements Closeable {
         } finally {
             busMapLock.writeLock().unlock();
         }
+        getConnector().close();
     }
 
     @Value

--- a/dbus-client/src/main/java/at/yawk/dbus/client/DbusClient.java
+++ b/dbus-client/src/main/java/at/yawk/dbus/client/DbusClient.java
@@ -78,7 +78,11 @@ public class DbusClient implements Closeable {
     }
 
     public <I> I implement(Class<I> interfaceClass) {
-        return rootFactory.createRmiInstance(interfaceClass);
+        return rootFactory.createRmiInstance(interfaceClass, null);
+    }
+    
+    public <I> I implement(Class<I> interfaceClass, DBUSDestination destination) {
+        return rootFactory.createRmiInstance(interfaceClass, destination);
     }
 
     @Override

--- a/dbus-client/src/main/java/at/yawk/dbus/client/RmiFactory.java
+++ b/dbus-client/src/main/java/at/yawk/dbus/client/RmiFactory.java
@@ -48,7 +48,13 @@ public class RmiFactory {
 
     @SuppressWarnings("unchecked")
     public <I> I createRmiInstance(Class<I> type) {
+        return createRmiInstance(type, null);
+    }
+    
+    @SuppressWarnings("unchecked")
+    public <I> I createRmiInstance(Class<I> type, final DBUSDestination destination) {
         CallSiteBuilder classSite = baseSite.createChild(false);
+        
         classSite.decorateFromClass(type);
         log.trace("Class call site for {} is {}", classSite, classSite);
 
@@ -73,6 +79,17 @@ public class RmiFactory {
 
             site = site.createChild(true);
             site.decorateFromCall(args);
+
+            if(destination != null && destination.getBus() != null) {
+                site.bus = destination.getBus();
+            }
+            if(destination != null && destination.getDestination() != null) {
+                site.destination = destination.getDestination();
+            }
+            if(destination != null && destination.getObjectPath() != null) {
+                site.objectPath = destination.getObjectPath();
+            }
+            
             return site.submit(executor);
         };
 

--- a/dbus-databind/src/main/java/at/yawk/dbus/databind/DataBinder.java
+++ b/dbus-databind/src/main/java/at/yawk/dbus/databind/DataBinder.java
@@ -34,6 +34,7 @@ public class DataBinder implements BinderFactoryContext {
         binderFactories.add(ArrayBinderFactory.getInstance());
         binderFactories.add(DictBinderFactory.getInstance());
         binderFactories.add(ObjectBinderFactory.getInstance());
+        binderFactories.add(StructBinderFactory.getInstance());
     }
 
     private <A extends Annotation> Optional<AnnotationBinderTransformer<?>> getBinderTransformer(

--- a/dbus-databind/src/main/java/at/yawk/dbus/databind/annotation/Struct.java
+++ b/dbus-databind/src/main/java/at/yawk/dbus/databind/annotation/Struct.java
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package at.yawk.dbus.databind.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Struct {
+}

--- a/dbus-databind/src/main/java/at/yawk/dbus/databind/annotation/StructMember.java
+++ b/dbus-databind/src/main/java/at/yawk/dbus/databind/annotation/StructMember.java
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package at.yawk.dbus.databind.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StructMember {
+    int position();
+}

--- a/dbus-databind/src/main/java/at/yawk/dbus/databind/binder/StructBinderFactory.java
+++ b/dbus-databind/src/main/java/at/yawk/dbus/databind/binder/StructBinderFactory.java
@@ -1,0 +1,176 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package at.yawk.dbus.databind.binder;
+
+import at.yawk.dbus.databind.annotation.StructMember;
+import at.yawk.dbus.databind.annotation.Struct;
+import at.yawk.dbus.protocol.object.DbusObject;
+import at.yawk.dbus.protocol.object.StructObject;
+import at.yawk.dbus.protocol.type.StructTypeDefinition;
+import at.yawk.dbus.protocol.type.TypeDefinition;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+
+public class StructBinderFactory implements BinderFactory {
+    @Getter
+    private static final StructBinderFactory instance = new StructBinderFactory();
+    
+    private final Map<Class,Binder<?>> binderMap = new LinkedHashMap<Class,Binder<?>>() {
+        @Override
+        protected boolean removeEldestEntry(Entry<Class,Binder<?>> eldest) {
+            return size() > 100;
+        }
+    };
+    
+    private StructBinderFactory() {}
+
+    @Override
+    public Binder<?> getBinder(BinderFactoryContext ctx, Type type) {
+        Class clazz = TypeUtil.getRawType(type);
+        
+        if(clazz.getAnnotation(Struct.class) == null) {
+            return null;
+        }
+        
+        Binder<?> binder = binderMap.get(clazz);
+        
+        if(binder == null) {
+            binder = new StructBinder(ctx, clazz);
+            binderMap.put(clazz, binder);
+        }
+
+        return binder;
+    }
+
+    @Override
+    public Binder<?> getDefaultEncodeBinder(BinderFactoryContext ctx, Type type) {
+        return getBinder(ctx, type);
+    }
+
+    @Override
+    public Binder<?> getDefaultDecodeBinder(BinderFactoryContext ctx, TypeDefinition typeDefinition) {
+        return null;
+    }
+
+    private static class StructBinder<X> implements Binder<X> {
+        private final static Pattern GETTER = Pattern.compile("(is|get)(\\p{javaUpperCase}.*)");
+        private final static Pattern SETTER = Pattern.compile("(set)(\\p{javaUpperCase}.*)");
+        
+        private final StructTypeDefinition definition;
+        private final TreeMap<Integer,Method> setterMap = new TreeMap<>();
+        private final TreeMap<Integer,Method> getterMap = new TreeMap<>();
+        private final TreeMap<Integer,Binder> binderMap = new TreeMap<>();
+        private final Class<? extends X> clazz;
+        
+        @SuppressWarnings("unchecked")
+        public StructBinder(BinderFactoryContext ctx, Class<? extends X> clazz) {
+            this.clazz = clazz;
+            Map<String,Integer> memberMap = new HashMap<>();
+            Map<String,Method> getter = new HashMap<>();
+            Map<String,Method> setter = new HashMap<>();
+            for(Method m: clazz.getMethods()) {
+                Matcher getterMatcher = GETTER.matcher(m.getName());
+                Matcher setterMatcher = SETTER.matcher(m.getName());
+                String propertyName = null;
+                if(getterMatcher.matches() && m.getParameterCount() == 0) {
+                    getter.put(getterMatcher.group(2), m);
+                    propertyName = getterMatcher.group(2);
+                } else if(setterMatcher.matches() && m.getParameterCount() == 1) {
+                    setter.put(setterMatcher.group(2), m);
+                    propertyName = setterMatcher.group(2);
+                }
+                if (propertyName != null) {
+                    StructMember sm = m.getAnnotation(StructMember.class);
+                    if (sm != null) {
+                        memberMap.put(propertyName, sm.position());
+                    }
+                }
+            }
+            for(Entry<String,Integer> e: memberMap.entrySet()) {
+                Class<?> clazzType = null;
+                Method setterMethod = setter.get(e.getKey());
+                Method getterMethod = getter.get(e.getKey());
+                if(setterMethod != null) {
+                    setterMap.put(e.getValue(), setterMethod);
+                    Class<?> clazzTypeSetter = setterMethod.getParameterTypes()[0];
+                    if(clazzType != null && clazzTypeSetter != clazzType) {
+                        throw new IllegalStateException("Getter and setter for member " + e.getKey() + " of " + clazz.getName());
+                    } else {
+                        clazzType = clazzTypeSetter;
+                    }
+                }
+                if(getterMethod != null) {
+                    getterMap.put(e.getValue(), getterMethod);
+                    Class<?> clazzTypeGetter = getterMethod.getReturnType();
+                    if(clazzType != null && clazzTypeGetter != clazzType) {
+                        throw new IllegalStateException("Getter and setter for member " + e.getKey() + " of " + clazz.getName());
+                    } else {
+                        clazzType = clazzTypeGetter;
+                    }
+                }
+                binderMap.put(e.getValue(), ctx.getBinder(clazzType));
+            }
+            
+            List<TypeDefinition> td = new ArrayList<>(binderMap.size());
+            for(Entry<Integer,Binder> sm: binderMap.entrySet()) {
+                td.add(sm.getValue().getType());
+            }
+            definition = new StructTypeDefinition(td);
+        }
+
+        @Override
+        public TypeDefinition getType() {
+            return definition;
+        }
+
+        @Override
+        public X decode(DbusObject busObject) {
+            try {
+                X object = clazz.getConstructor().newInstance();
+                for(int i = 0; i < setterMap.size(); i++) {
+                    if(setterMap.containsKey(i) && binderMap.containsKey(i)) {
+                        Method setter = setterMap.get(i);
+                        Binder binder = binderMap.get(i);
+                        setter.invoke(object, binder.decode(busObject.get(i)));
+                    }
+                }
+                return object;
+            } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        @Override
+        public DbusObject encode(X obj) {
+            try {
+                List<DbusObject> data = new ArrayList<>(getterMap.size());
+                for (int i = 0; i < getterMap.size(); i++) {
+                    if (getterMap.containsKey(i) && binderMap.containsKey(i)) {
+                        Method getter = getterMap.get(i);
+                        Binder binder = binderMap.get(i);
+                        data.set(i, binder.encode(getter.invoke(obj)));
+                    }
+                }
+                return StructObject.create(definition, data);
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
This PR adds minimal support to dbus-java to communiticate with the evolution data server. To do this, the following issue had to be fixed:

- EDS makes its multiple calendars, tudo-lists and memos (and more) available as objects on the dbus, which all implement the same interface, but are bound to different objectPaths
- EDS makes use of structs for returns and thus these need to be bound.
- DbusClient does not propertly shut down the EventLoopGroups 

There is more explanation in the individual commits. To make it easier to follow I created this repository:

https://github.com/matthiasblaesing/dbus-java-test

This shows the shutdown problem in isolation:
https://github.com/matthiasblaesing/dbus-java-test/blob/2866392d01fa8f164176d0e7242684bfd36161da/src/main/java/eu/doppelhelix/dev/dbustest/TrivialClientTest.java

This shows the struct and multiple object path binding in action:
https://github.com/matthiasblaesing/dbus-java-test/blob/master/src/main/java/eu/doppelhelix/dev/dbustest/EvolutionExample.java